### PR TITLE
Update terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ Huge thanks to the original creator [LordRatte](https://github.com/LordRatte) fo
 3. **Start editing!** Your changes are automatically saved back to Google Drive
 4. **Customize settings** via the gear button
 
-> The app only requests minimal Google Drive permissions (drive.file scope) - it can only access files you explicitly choose to open with it.
+> The app requests the following Google Drive permissions:
+>
+> - `drive.file` - Core functionality to read and write files you explicitly choose to open
+> - `drive.install` - Required for the "Open With" option in Google Drive's context menu
+> - `userinfo.email` and `userinfo.profile` - Required for Google Workspace Marketplace publishing (data is not used by the app)
 
 ## ✨ Key Features
 
@@ -72,7 +76,10 @@ The app adds only a small gear icon to your TiddlyWiki, keeping the interface cl
 ### 🌐 Enterprise Features
 
 - Shared Drive support for team collaboration
-- Minimal permissions (drive.file scope only)
+- Minimal permissions with clear scope justifications:
+  - `drive.file` - Access only files you explicitly open
+  - `drive.install` - Enable Google Drive "Open With" integration
+  - `userinfo.email` and `userinfo.profile` - Required for marketplace publishing only
 - Offline fallback for network interruptions
 
 ## 🔧 Development

--- a/app/src/app.html
+++ b/app/src/app.html
@@ -4,7 +4,7 @@
     <title>Tiddly Drive 2 – Open & Save TiddlyWiki Files from Google Drive</title>
     <meta
       name="description"
-      content="Tiddly Drive 2 lets you securely open, edit, and save single‑file TiddlyWiki documents stored in your Google Drive using minimal OAuth scope (drive.file) and a privacy‑first, client‑only approach."
+      content="Tiddly Drive 2 lets you securely open, edit, and save single‑file TiddlyWiki documents stored in your Google Drive using minimal OAuth scopes (drive.file) and a privacy‑first, client‑only approach."
     />
     <meta
       name="keywords"

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -1,5 +1,16 @@
 import type { GoogleOAuth2TokenResponse, GoogleTokenClient } from './types.js';
 
+/*
+ * Google Drive API Scope Strategy:
+ * - drive.file: Core functionality - access only files user explicitly opens
+ * - drive.install: Required for "Open With" option in Google Drive context menu
+ * - userinfo.email & userinfo.profile: Required for Google Workspace Marketplace publishing
+ *   (these are not used by the app but required by Google's marketplace policies)
+ *
+ * In development, only drive.file is used by default. The broader 'drive' scope can be
+ * temporarily enabled via URL parameter for testing purposes.
+ */
+
 const DEFAULT_SCOPE = 'https://www.googleapis.com/auth/drive.file';
 const CLIENT_ID = '477983451498-28pnsm6sgqfm5l2gk0pris227couk477.apps.googleusercontent.com';
 const WEB_API_KEY = 'AIzaSyBa2pekTr_FkdjYQlZDjHGuuxwNO6EY9Pg';

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -113,14 +113,14 @@
   .app-shell {
     margin: 0;
     padding: 0;
-    height: 100%;
   }
   .app-shell {
     font-family: system-ui, sans-serif;
-    background: #111;
     color: #222;
+    display: flex;
+    flex-direction: column;
     min-height: 100vh;
-    position: relative;
+    background-color: #e0e0e0;
   }
   .frame-wrapper {
     position: relative;

--- a/app/src/routes/info/+page.svelte
+++ b/app/src/routes/info/+page.svelte
@@ -18,6 +18,7 @@
     <ul class="feature-list">
       <li>
         <strong>Minimal Scope:</strong> Uses only <code>drive.file</code> for the files you choose.
+        <sup>1</sup>
       </li>
       <li><strong>Client‑Side Only:</strong> No server stores your content.</li>
       <li><strong>Open Source:</strong> GNU licensed and community friendly.</li>
@@ -38,6 +39,11 @@
       <a data-sveltekit-preload-data="hover" href={resolve('/info/terms')}>Terms of Service</a>
     </div>
   </section>
+  <p class="scope-caveat">
+    <sup>1</sup> Additional scopes (<code>drive.install</code>,
+    <code>userinfo.email</code>, <code>userinfo.profile</code>) are required for Google Drive "Open
+    With" integration and marketplace publishing but are not used by the application.
+  </p>
 </main>
 
 <style>
@@ -70,6 +76,15 @@
     border-radius: 12px;
     box-shadow: 0 2px 4px var(--color-shadow-light);
     font-size: 0.95rem;
+  }
+  .scope-caveat {
+    margin-top: 0.75rem;
+    font-size: 0.8rem;
+    color: var(--color-text-muted, #666);
+    text-align: center;
+    max-width: 600px;
+    margin-left: auto;
+    margin-right: auto;
   }
   .actions {
     margin-top: 2.25rem;

--- a/app/src/routes/info/privacy/+page.svelte
+++ b/app/src/routes/info/privacy/+page.svelte
@@ -31,11 +31,22 @@
       <li>No account emails, contacts, or any other Drive files beyond the one you choose.</li>
     </ul>
     <h2>OAuth Scope Justification</h2>
-    <p>
-      The app requests only the <code>https://www.googleapis.com/auth/drive.file</code> scope so it can
-      read and update the specific file you pick. This does not grant broad read access to your entire
-      Drive.
-    </p>
+    <p>The app requests the following Google API scopes:</p>
+    <ul>
+      <li>
+        <code>https://www.googleapis.com/auth/drive.file</code> - Core functionality to read and update
+        the specific file you pick. This does not grant broad read access to your entire Drive.
+      </li>
+      <li>
+        <code>https://www.googleapis.com/auth/drive.install</code> - Required for the "Open With" option
+        to appear in Google Drive's context menu when you right-click files.
+      </li>
+      <li>
+        <code>https://www.googleapis.com/auth/userinfo.email</code> and
+        <code>https://www.googleapis.com/auth/userinfo.profile</code> - Required for Google Workspace
+        Marketplace publishing. This data is not used, stored, or accessed by the application.
+      </li>
+    </ul>
     <h2>Data Storage & Retention</h2>
     <p>
       No persistent storage outside your browser’s runtime is used. When you close the tab, the

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,7 +38,13 @@ This project is a modernized Tiddly Drive app built with Svelte 5 and Vite. It i
 
 For testing or app review, you may need to use the broader `drive` scope (for example, to enable Google Drive's "Open with" flow before the app is fully verified). You can opt-in via a URL query parameter; no rebuild is required, and it works locally and in production.
 
-- Default scope: `drive.file` (least privilege)
+**Production scopes** (what users actually experience):
+- `drive.file` - Core functionality to read and write files you explicitly choose to open
+- `drive.install` - Required for the "Open With" option in Google Drive's context menu  
+- `userinfo.email` and `userinfo.profile` - Required for Google Workspace Marketplace publishing (data is not used by the app)
+
+**Development/testing scope override**:
+- Default scope: `drive.file` (least privilege for development)
 - Override via query param:
   - `?td_scope=drive` → uses `https://www.googleapis.com/auth/drive`
   - `?td_scope=drive.file` or omit param → uses `https://www.googleapis.com/auth/drive.file`


### PR DESCRIPTION
With new scopes that were required to publish.

Also fixes the problem with the landing page when no file is there. Just makes it less jarring on the eyes.